### PR TITLE
Add tests for filename normalization

### DIFF
--- a/normalize_test.go
+++ b/normalize_test.go
@@ -1,0 +1,46 @@
+package main
+
+import "testing"
+
+func TestNormalizeFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "spaces replaced with hyphens",
+			input:    "My File.txt",
+			expected: "my-file.txt",
+		},
+		{
+			name:     "case converted to lowercase",
+			input:    "HELLO.txt",
+			expected: "hello.txt",
+		},
+		{
+			name:     "forbidden characters replaced",
+			input:    "file@name!.txt",
+			expected: "file-name.txt",
+		},
+		{
+			name:     "multiple hyphens collapsed",
+			input:    "file--name---test.txt",
+			expected: "file-name-test.txt",
+		},
+		{
+			name:     "extension lowercased",
+			input:    "report.PDF",
+			expected: "report.pdf",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeFilename(tc.input)
+			if got != tc.expected {
+				t.Fatalf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add table-driven unit tests for `normalizeFilename`
- cover spaces, case conversion, forbidden characters, multiple hyphens, and extension casing

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b66df5684883299f16c5423dfeafa4