### PR TITLE
use built-in flag help

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Welcome contributors! To keep this repository consistent and helpful for both hu
 2. Run `go fmt ./...`, `go vet ./...`, and `go test ./...` after making changes.
 3. Ensure all text files end with a single trailing newline.
 4. Update both `README.md` and this `AGENTS.md` whenever your changes affect project behavior, usage, or contributor guidance.
+5. The CLI relies on Go's built-in `-h`/`--help` flags for usage information.
 
 Thank you for helping maintain fnorm.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ fnorm *.jpg
 ## Flags
 
 - `-dry-run`: Preview changes without applying them
-- `-help`: Show help message
+- `-h`, `--help`: Show help message
 
 ## Building
 

--- a/main.go
+++ b/main.go
@@ -11,21 +11,16 @@ import (
 
 var (
 	dryRun = flag.Bool("dry-run", false, "Show what would be renamed without making changes")
-	help   = flag.Bool("help", false, "Show help message")
 )
 
 func main() {
+	flag.Usage = showHelp
 	flag.Parse()
-
-	if *help {
-		showHelp()
-		return
-	}
 
 	args := flag.Args()
 	if len(args) == 0 {
 		fmt.Fprintf(os.Stderr, "Error: No files specified\n")
-		fmt.Fprintf(os.Stderr, "Use -help for usage information\n")
+		fmt.Fprintf(os.Stderr, "Use -h or --help for usage information\n")
 		os.Exit(1)
 	}
 
@@ -48,7 +43,7 @@ Normalizes file names according to standards:
 
 Flags:
   -dry-run    Show what would be renamed without making changes
-  -help       Show this help message
+  -h, --help  Show this help message
 
 Examples:
   fnorm "My Document.PDF"              # -> my-document.pdf
@@ -60,32 +55,32 @@ Examples:
 func processFile(filePath string) error {
 	dir := filepath.Dir(filePath)
 	filename := filepath.Base(filePath)
-	
+
 	normalized := normalizeFilename(filename)
-	
+
 	if filename == normalized {
 		if !*dryRun {
 			fmt.Printf("✓ %s (no changes needed)\n", filename)
 		}
 		return nil
 	}
-	
+
 	newPath := filepath.Join(dir, normalized)
-	
+
 	if *dryRun {
 		fmt.Printf("Would rename: %s -> %s\n", filename, normalized)
 		return nil
 	}
-	
+
 	// Check if target exists
 	if _, err := os.Stat(newPath); err == nil {
 		return fmt.Errorf("target file already exists: %s", normalized)
 	}
-	
+
 	if err := os.Rename(filePath, newPath); err != nil {
 		return fmt.Errorf("failed to rename: %v", err)
 	}
-	
+
 	fmt.Printf("Renamed: %s -> %s\n", filename, normalized)
 	return nil
 }
@@ -94,30 +89,30 @@ func normalizeFilename(filename string) string {
 	// Get file extension
 	ext := filepath.Ext(filename)
 	nameOnly := strings.TrimSuffix(filename, ext)
-	
+
 	// Apply transformations to name only
 	result := nameOnly
-	
+
 	// 1. Replace spaces with hyphens
 	result = strings.ReplaceAll(result, " ", "-")
-	
+
 	// 2. Convert to lowercase
 	result = strings.ToLower(result)
-	
+
 	// 3. Replace forbidden characters with hyphens
 	// Keep only: letters, numbers, hyphens, underscores, periods
 	reg := regexp.MustCompile(`[^a-z0-9\-_.]`)
 	result = reg.ReplaceAllString(result, "-")
-	
+
 	// 4. Clean up multiple consecutive hyphens
 	reg = regexp.MustCompile(`-+`)
 	result = reg.ReplaceAllString(result, "-")
-	
+
 	// 5. Trim leading/trailing hyphens
 	result = strings.Trim(result, "-")
-	
+
 	// Convert extension to lowercase too
 	ext = strings.ToLower(ext)
-	
+
 	return result + ext
 }


### PR DESCRIPTION
## Summary
- remove custom -help flag and register help text via flag.Usage
- document built-in -h/--help usage in README and AGENTS

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6fcc5756883298c3f471154e0bc5f