### PR TITLE
Add Go CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Go fmt
+        run: |
+          gofmt -w $(git ls-files '*.go')
+          git diff --exit-code
+      - name: Go vet
+        run: go vet ./...
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+      - name: Go test
+        run: go test ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ go test -v -run TestNormalizeFilename
 # Format and lint code (run before committing)
 go fmt ./...
 go vet ./...
+golangci-lint run
 
 # Build for all platforms
 make build-all
@@ -71,5 +72,9 @@ Tests use table-driven testing pattern with test cases covering:
 
 - Go 1.25 or later required
 - All text files must end with a single trailing newline
-- Run `go fmt`, `go vet`, and `go test` before committing changes
+- Run `go fmt`, `go vet`, `golangci-lint run`, and `go test` before committing changes
 - **Update both README.md and AGENTS.md when making changes that affect project behavior, usage, or contributor guidelines**
+
+## CI
+
+A GitHub Actions workflow (`.github/workflows/ci.yml`) runs `go fmt`, `go vet`, `golangci-lint run`, and `go test ./...` on every push and pull request.

--- a/README.md
+++ b/README.md
@@ -79,12 +79,16 @@ make clean
 
 This project was developed with AI assistance.
 
+## CI
+
+A GitHub Actions workflow in `.github/workflows/ci.yml` runs on every push and pull request. It ensures the codebase passes `go fmt`, `go vet`, `golangci-lint run`, and `go test ./...`.
+
 ## Contributing
 
 Contributions are welcome. To keep the project consistent and easy to work with:
 
 - Use Go 1.25 or later.
-- Run `go fmt ./...`, `go vet ./...`, and `go test ./...` before submitting changes.
+- Run `go fmt ./...`, `go vet ./...`, `golangci-lint run`, and `go test ./...` before submitting changes.
 - Ensure all text files end with a trailing newline.
 - Update both `README.md` and `AGENTS.md` whenever your changes affect project behavior or contributor instructions.
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run go fmt, go vet, golangci-lint, and go test
- document CI workflow and contributor commands in README
- update AGENTS instructions for new lint and CI

## Testing
- `go fmt ./...`
- `timeout 10s go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b70bfda638832982ca4f64d3d21c51