### PR TITLE
refactor: extract normalization package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ go.work
 go.work.sum
 
 # Project binary
-fnorm
-fnorm_unix
+/fnorm
+/fnorm_unix
 
 # env file
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,14 +42,15 @@ go run . [flags] file1 [file2 ...]
 
 ## Architecture
 
-This is a simple Go CLI tool with a single main package containing:
+This project is organized into separate command and library packages:
 
-- **main.go**: Entry point with CLI flag parsing, file processing logic, and the core `normalizeFilename()` function
-- **normalize_test.go**: Table-driven tests for the normalization logic
+- **cmd/fnorm/main.go**: CLI entry point with flag parsing and file processing logic
+- **pkg/fnorm/normalize.go**: Library package exporting the `Normalize` function
+- **pkg/fnorm/normalize_test.go**: Table-driven tests for the normalization logic
 - **tools.go**: Development tool dependencies (build tag: tools)
 - **.golangci.yml**: Linter configuration
 
-The normalization pipeline in `normalizeFilename()`:
+The normalization pipeline in `Normalize()`:
 
 1. Separates extension from filename
 2. Replaces spaces with hyphens

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ A simple Go tool that normalizes file names according to consistent standards.
 - Cleans up multiple consecutive hyphens
 - Preserves file extensions
 
+## Project Layout
+
+- `cmd/fnorm/main.go`: command-line entry point
+- `pkg/fnorm/normalize.go`: library package providing `Normalize`
+- `pkg/fnorm/normalize_test.go`: table-driven tests for normalization
+
 ## Installation
 
 ```bash

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,4 @@
+// Package fnorm is the root package of the fnorm module.
+// It exists to satisfy Go tooling when the module has no
+// non-build-tagged Go files at the module root.
+package fnorm

--- a/pkg/fnorm/normalize.go
+++ b/pkg/fnorm/normalize.go
@@ -1,0 +1,50 @@
+// Package fnorm provides filename normalization utilities.
+package fnorm
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	spaceReplacer         = "-"
+	forbiddenCharsPattern = `[^a-z0-9\-_.]`
+)
+
+var (
+	forbiddenCharsRe = regexp.MustCompile(forbiddenCharsPattern)
+	multiHyphenRe    = regexp.MustCompile(`-+`)
+)
+
+// Normalize transforms a filename according to the normalization rules:
+// spaces to hyphens, lowercase conversion, forbidden character replacement, etc.
+func Normalize(filename string) string {
+	// Get file extension
+	ext := filepath.Ext(filename)
+	nameOnly := strings.TrimSuffix(filename, ext)
+
+	// Apply transformations to name only
+	result := nameOnly
+
+	// 1. Replace spaces with hyphens
+	result = strings.ReplaceAll(result, " ", spaceReplacer)
+
+	// 2. Convert to lowercase
+	result = strings.ToLower(result)
+
+	// 3. Replace forbidden characters with hyphens
+	// Keep only: letters, numbers, hyphens, underscores, periods
+	result = forbiddenCharsRe.ReplaceAllString(result, "-")
+
+	// 4. Clean up multiple consecutive hyphens
+	result = multiHyphenRe.ReplaceAllString(result, "-")
+
+	// 5. Trim leading/trailing hyphens
+	result = strings.Trim(result, "-")
+
+	// Convert extension to lowercase too
+	ext = strings.ToLower(ext)
+
+	return result + ext
+}

--- a/pkg/fnorm/normalize_test.go
+++ b/pkg/fnorm/normalize_test.go
@@ -1,8 +1,8 @@
-package main
+package fnorm
 
 import "testing"
 
-func TestNormalizeFilename(t *testing.T) {
+func TestNormalize(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -37,7 +37,7 @@ func TestNormalizeFilename(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := normalizeFilename(tc.input)
+			got := Normalize(tc.input)
 			if got != tc.expected {
 				t.Fatalf("expected %q, got %q", tc.expected, got)
 			}


### PR DESCRIPTION
## Summary
- move CLI entry point into cmd/fnorm
- expose Normalize in pkg/fnorm
- update tests and docs for new project layout
- document packages and silence linter warnings

## Testing
- `make tools` *(fails: module download forbidden)*
- `make check`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b7b7f1acdc8329b7c3a75ce36f4f89