### PR TITLE
refactor: move normalization logic to internal package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ make vet         # Run go vet
 
 # Run tests
 go test -v
-go test -v -run TestNormalizeFilename  # Run specific test
+go test -v -run TestNormalize  # Run specific test
 
 # Build for all platforms
 make build-all
@@ -45,8 +45,8 @@ go run . [flags] file1 [file2 ...]
 This project is organized into separate command and library packages:
 
 - **cmd/fnorm/main.go**: CLI entry point with flag parsing and file processing logic
-- **pkg/fnorm/normalize.go**: Library package exporting the `Normalize` function
-- **pkg/fnorm/normalize_test.go**: Table-driven tests for the normalization logic
+- **internal/normalize/normalize.go**: Library package exporting the `Normalize` function
+- **internal/normalize/normalize_test.go**: Table-driven tests for the normalization logic
 - **tools.go**: Development tool dependencies (build tag: tools)
 - **.golangci.yml**: Linter configuration
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ A simple Go tool that normalizes file names according to consistent standards.
 ## Project Layout
 
 - `cmd/fnorm/main.go`: command-line entry point
-- `pkg/fnorm/normalize.go`: library package providing `Normalize`
-- `pkg/fnorm/normalize_test.go`: table-driven tests for normalization
+- `internal/normalize/normalize.go`: library package providing `Normalize`
+- `internal/normalize/normalize_test.go`: table-driven tests for normalization
 
 ## Installation
 

--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,7 @@ This file tracks improvements to align the project with Go conventions and best 
   ```
 
 - [x] **Add function documentation** for all functions: ✅ _Completed - added proper Go doc comments_
-  - [x] `normalizeFilename` - Core normalization logic
+  - [x] `Normalize` - Core normalization logic
   - [x] `processFile` - File processing with error handling
   - [x] `showHelp` - Usage information display
 
@@ -49,7 +49,7 @@ This file tracks improvements to align the project with Go conventions and best 
   return fmt.Errorf("target file already exists %q: %w", normalized, os.ErrExist)
   ```
 
-- [x] **Add validation** in normalizeFilename for edge cases
+- [x] **Add validation** in Normalize for edge cases
   - [x] Handle empty input strings
   - [x] Handle files starting/ending with dots
 
@@ -65,9 +65,9 @@ This file tracks improvements to align the project with Go conventions and best 
 - [x] **Create benchmark tests** (new file: normalize_bench_test.go)
 
   ```go
-  func BenchmarkNormalizeFilename(b *testing.B) {
+  func BenchmarkNormalize(b *testing.B) {
       for i := 0; i < b.N; i++ {
-          normalizeFilename("My Complex File Name (Copy) #1.PDF")
+          Normalize("My Complex File Name (Copy) #1.PDF")
       }
   }
   ```
@@ -76,22 +76,22 @@ This file tracks improvements to align the project with Go conventions and best 
 
 ### Project Layout (Standard Go Project)
 
-- [ ] **Create cmd directory structure**
-  - [ ] Move main.go → cmd/fnorm/main.go
-  - [ ] Create internal/normalize/ package
+- [x] **Create cmd directory structure**
+  - [x] Move main.go → cmd/fnorm/main.go
+  - [x] Create internal/normalize/ package
 
-- [ ] **Separate CLI from business logic**
-  - [ ] Create normalize.go in internal/normalize/
-  - [ ] Export Filename function
-  - [ ] Keep main.go focused on CLI concerns
+- [x] **Separate CLI from business logic**
+  - [x] Create normalize.go in internal/normalize/
+  - [x] Export Normalize function
+  - [x] Keep main.go focused on CLI concerns
 
 ### Additional Testing
 
-- [ ] **Add example tests** (example_test.go)
+- [x] **Add example tests** (example_test.go)
 
   ```go
-  func ExampleNormalizeFilename() {
-      result := normalizeFilename("My File.PDF")
+  func ExampleNormalize() {
+      result := Normalize("My File.PDF")
       fmt.Println(result)
       // Output: my-file.pdf
   }

--- a/cmd/fnorm/main.go
+++ b/cmd/fnorm/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	fnorm "github.com/laydros/fnorm/pkg/fnorm" //nolint:depguard // internal package import
+	normalize "github.com/laydros/fnorm/internal/normalize" //nolint:depguard // internal package import
 )
 
 var (
@@ -78,7 +78,7 @@ func processFile(filePath string) error {
 	dir := filepath.Dir(filePath)
 	filename := filepath.Base(filePath)
 
-	normalized := fnorm.Normalize(filename)
+	normalized := normalize.Normalize(filename)
 
 	// If no change is needed
 	if filename == normalized {

--- a/internal/normalize/example_test.go
+++ b/internal/normalize/example_test.go
@@ -1,0 +1,13 @@
+package normalize_test
+
+import (
+	"fmt"
+
+	normalize "github.com/laydros/fnorm/internal/normalize" //nolint:depguard // internal package import
+)
+
+func ExampleNormalize() {
+	result := normalize.Normalize("My File.PDF")
+	fmt.Println(result)
+	// Output: my-file.pdf
+}

--- a/internal/normalize/normalize.go
+++ b/internal/normalize/normalize.go
@@ -1,5 +1,5 @@
-// Package fnorm provides filename normalization utilities.
-package fnorm
+// Package normalize provides filename normalization utilities.
+package normalize
 
 import (
 	"path/filepath"

--- a/internal/normalize/normalize_bench_test.go
+++ b/internal/normalize/normalize_bench_test.go
@@ -1,8 +1,8 @@
-package fnorm
+package normalize
 
 import "testing"
 
-func BenchmarkNormalizeFilename(b *testing.B) {
+func BenchmarkNormalize(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Normalize("My Complex File Name (Copy) #1.PDF")
 	}

--- a/internal/normalize/normalize_test.go
+++ b/internal/normalize/normalize_test.go
@@ -1,4 +1,4 @@
-package fnorm
+package normalize
 
 import "testing"
 


### PR DESCRIPTION
## Summary
- move filename normalization into `internal/normalize`
- expose `Normalize` instead of `Filename`
- update CLI, tests, and docs to match

## Testing
- `make check`
- `go test -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bf7a7b13d08329a61ee9212a4c19bf