### PR TITLE
Add coverage make target and report in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,10 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
-      - name: Go test
-        run: go test ./...
+      - name: Coverage
+        run: make coverage
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ make check
 
 # Individual checks
 make test        # Run tests
+make coverage    # Run tests with coverage profile
 make lint        # Run golangci-lint
 make fmt         # Format code
 make vet         # Run go vet -all
@@ -103,4 +104,4 @@ make check   # Verify everything works
 
 ## CI
 
-A GitHub Actions workflow (`.github/workflows/ci.yml`) runs `go fmt`, `go vet -all`, `golangci-lint run`, and `go test ./...` on every push and pull request.
+A GitHub Actions workflow (`.github/workflows/ci.yml`) runs `go fmt`, `go vet -all`, `golangci-lint run`, and `make coverage` on every push and pull request, uploading `coverage.out` as an artifact.

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ clean:
 test:
 	go test -v
 
+coverage:
+	go test -coverprofile=coverage.out ./...
+
 run:
 	go run . $(ARGS)
 
@@ -54,5 +57,5 @@ build-all: build build-linux build-windows
 install: build
 	cp $(BINARY_NAME) ~/bin/
 
-.PHONY: build clean test run tools lint fmt vet check build-linux build-windows build-all install
+.PHONY: build clean test coverage run tools lint fmt vet check build-linux build-windows build-all install
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ make check  # runs fmt, vet, lint, and test
 ```bash
 make build       # Build the binary
 make test        # Run tests
+make coverage    # Run tests with coverage report
 make tools       # Install development tools
 make lint        # Run golangci-lint
 make fmt         # Format code
@@ -179,7 +180,7 @@ This project was developed with AI assistance.
 
 ## CI
 
-A GitHub Actions workflow in `.github/workflows/ci.yml` runs on every push and pull request. It ensures the codebase passes `go fmt`, `go vet -all`, `golangci-lint run`, and `go test ./...`.
+A GitHub Actions workflow in `.github/workflows/ci.yml` runs on every push and pull request. It ensures the codebase passes `go fmt`, `go vet -all`, `golangci-lint run`, and `make coverage` (tests with coverage).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- add `coverage` target running `go test -coverprofile=coverage.out ./...`
- run coverage in CI and upload `coverage.out` artifact
- document `make coverage` in repository guides

## Testing
- `make coverage`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68bfa648aa948329a93c0ff07870d4b2