### PR TITLE
Update CI for Rust project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,29 +5,24 @@ on:
   pull_request:
 
 jobs:
-  build:
+  checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          go-version-file: go.mod
-      - name: Go fmt
-        run: |
-          gofmt -w $(git ls-files '*.go')
-          git diff --exit-code
-      - name: Go vet
-        run: go vet -all ./...
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
-      - name: Coverage
-        run: make coverage
-      - name: Integration Tests
-        run: make test-integration
-      - name: Upload coverage
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage
-          path: coverage.out
+          components: clippy, rustfmt
+
+      - name: Cache cargo builds
+        uses: Swatinem/rust-cache@v2
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Tests
+        run: cargo test --workspace --all-targets


### PR DESCRIPTION
## Summary
- replace the Go-centric workflow with a Rust toolchain setup
- run cargo fmt, clippy, and tests in GitHub Actions with caching for build artifacts

## Testing
- cargo fmt
- cargo clippy --all-targets *(fails: unable to reach crates.io due to 403)*
- cargo test --workspace --all-targets *(fails: unable to reach crates.io due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e4a608f883298d4fb528091c8de1