### PR TITLE
Support directory renames and tweak CLI flags

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,10 +4,6 @@ use std::path::PathBuf;
 
 #[derive(Debug)]
 pub enum FnormError {
-    NotAFile {
-        path: PathBuf,
-        source: io::Error,
-    },
     FileNotFound {
         path: PathBuf,
         source: io::Error,
@@ -25,9 +21,6 @@ pub enum FnormError {
 impl fmt::Display for FnormError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            FnormError::NotAFile { path, .. } => {
-                write!(f, "skipping directory: {}: is a directory", path.display())
-            }
             FnormError::FileNotFound { path, .. } => {
                 write!(f, "file not found: {}", path.display())
             }
@@ -50,7 +43,6 @@ impl fmt::Display for FnormError {
 impl std::error::Error for FnormError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            FnormError::NotAFile { source, .. } => Some(source),
             FnormError::FileNotFound { source, .. } => Some(source),
             FnormError::RenameError { source, .. } => Some(source),
             FnormError::TargetExists { .. } => None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod error;
 mod normalize;
 
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use std::error::Error as StdError;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -16,9 +16,14 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
     name = "fnorm",
     version = VERSION,
     about = "Normalize filenames to ASCII-only slug format",
-    long_about = "Convert filenames to normalized, ASCII-only slug format while retaining directory location and file extensions."
+    long_about = "Convert filenames to normalized, ASCII-only slug format while retaining directory location and file extensions.",
+    disable_version_flag = true
 )]
 struct Cli {
+    /// Print the version
+    #[arg(short = 'v', long = "version", action = ArgAction::Version)]
+    _version: bool,
+
     /// Print what would be done without making changes
     #[arg(long)]
     dry_run: bool,
@@ -88,17 +93,10 @@ fn process_file(path: &Path, dry_run: bool) -> Result<(), FnormError> {
     use std::fs;
     use std::io::{self, ErrorKind};
 
-    let metadata = fs::metadata(path).map_err(|source| FnormError::FileNotFound {
+    fs::metadata(path).map_err(|source| FnormError::FileNotFound {
         path: path.to_path_buf(),
         source,
     })?;
-
-    if metadata.is_dir() {
-        return Err(FnormError::NotAFile {
-            path: path.to_path_buf(),
-            source: io::Error::new(ErrorKind::Other, "path is a directory"),
-        });
-    }
 
     let filename = path
         .file_name()


### PR DESCRIPTION
## Summary
- allow `fnorm` to normalize and rename directories using the existing file-handling flow
- simplify error handling by removing the directory-specific error variant
- customize the CLI to expose a lowercase `-v/--version` flag and tidy the help text

## Testing
- cargo fmt
- cargo check --offline *(fails: no matching package named `clap` found while offline)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc9e3d1588329a3f9edf5ad6f4c51