### PR TITLE
Add configurable normalization via TOML config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ cargo run -- --dry-run [files...]
 
 ### Testing
 ```bash
-# Run all tests (26 total: 11 unit + 15 integration)
+# Run all tests (27 total: 12 unit + 15 integration)
 cargo test
 
 # Run with output

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ categories = ["command-line-utilities", "filesystem"]
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ cargo run -- "My Directory"
 
 # Preview changes without renaming
 cargo run -- --dry-run "My Document.PDF"
+
+# Use a custom config file
+cargo run -- --config ./fnorm.toml "My Document.PDF"
 ```
 
 The CLI prints status messages such as:
@@ -93,7 +96,7 @@ Errors (missing paths, collisions, rename failures) are reported to standard err
 
 The project includes both unit tests and integration tests:
 
-- **Unit tests** (11 tests) in `src/normalize.rs` cover the normalization algorithm
+- **Unit tests** (12 tests) in `src/normalize.rs` cover the normalization algorithm
 - **Integration tests** (15 tests) in `tests/integration_tests.rs` verify file/directory operations
 
 Run all tests with:
@@ -118,6 +121,28 @@ The normalization pipeline follows the twelve-step algorithm described in detail
 2. Replace spaces with hyphens and convert to lowercase.
 3. Substitute special tokens: `/` → `-or-`, `&` → `-and-`, `@` → `-at-`, `%` → `-percent-`.
 4. Transliterate select accented characters (e.g., `é` → `e`, `ß` → `ss`).
+
+## Configuration
+
+Pass `--config <path>` to supply a TOML file that customizes the normalization pipeline. All fields are optional; any values you provide override the built-in defaults.
+
+```toml
+[special_tokens]
+"&" = "-and-"
+"/" = "-slash-"
+
+[transliterations]
+"ø" = "oe"
+
+[options]
+lowercase = true
+lowercase_extension = true
+```
+
+- **special_tokens**: single-character keys mapped to replacement strings.
+- **transliterations**: single-character keys mapped to ASCII strings.
+- **options.lowercase**: whether to lowercase the base name (default: `true`).
+- **options.lowercase_extension**: whether to lowercase the extension (default: `true`).
 5. Replace any remaining unsupported characters with hyphens and collapse hyphen runs.
 6. Lowercase the file extension before reassembling the final name.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,52 @@
 use std::fmt;
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+use toml::de::Error as TomlError;
+
+#[derive(Debug)]
+pub enum ConfigError {
+    Io {
+        path: PathBuf,
+        source: io::Error,
+    },
+    Parse {
+        path: Option<PathBuf>,
+        source: TomlError,
+    },
+    InvalidKey {
+        section: &'static str,
+        key: String,
+    },
+}
+
+impl ConfigError {
+    pub fn io(path: PathBuf, source: io::Error) -> Self {
+        Self::Io { path, source }
+    }
+
+    pub fn from_parse_error(source: TomlError) -> Self {
+        Self::Parse { path: None, source }
+    }
+
+    pub fn from_parse_error_with_path(path: &Path, source: TomlError) -> Self {
+        Self::Parse {
+            path: Some(path.to_path_buf()),
+            source,
+        }
+    }
+
+    pub fn char_from_key(section: &'static str, key: &str) -> Result<char, Self> {
+        let mut chars = key.chars();
+        match (chars.next(), chars.next()) {
+            (Some(ch), None) => Ok(ch),
+            _ => Err(Self::InvalidKey {
+                section,
+                key: key.to_string(),
+            }),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum FnormError {
@@ -40,6 +86,26 @@ impl fmt::Display for FnormError {
     }
 }
 
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConfigError::Io { path, .. } => {
+                write!(f, "failed to read config at {}", path.display())
+            }
+            ConfigError::Parse {
+                path: Some(path), ..
+            } => {
+                write!(f, "failed to parse config at {}", path.display())
+            }
+            ConfigError::Parse { path: None, .. } => write!(f, "failed to parse config"),
+            ConfigError::InvalidKey { section, key } => write!(
+                f,
+                "invalid key \"{key}\" in {section}; use single-character keys"
+            ),
+        }
+    }
+}
+
 impl std::error::Error for FnormError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
@@ -47,6 +113,16 @@ impl std::error::Error for FnormError {
                 Some(source)
             }
             FnormError::TargetExists { .. } => None,
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ConfigError::Io { source, .. } => Some(source),
+            ConfigError::Parse { source, .. } => Some(source),
+            ConfigError::InvalidKey { .. } => None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
-use fnorm::{run, Cli, RunError};
+use fnorm::{run, AppError, Cli};
 
-fn main() -> Result<(), RunError> {
+fn main() -> Result<(), AppError> {
     let cli = Cli::parse();
     run(&cli)
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -19,6 +19,7 @@ fn run_fnorm(path: &Path, dry_run: bool) -> Result<(), String> {
 
     let cli = Cli {
         dry_run,
+        config: None,
         files: vec![path.to_path_buf()],
     };
 


### PR DESCRIPTION
## Summary
- add a NormalizationConfig with TOML parsing so the pipeline can be customized
- wire the CLI with a new --config flag and broader error handling for configuration failures
- document the configuration schema and extend unit coverage for custom rules

## Testing
- cargo fmt
- cargo clippy *(fails: unable to reach crates.io index in this environment)*
- cargo test *(fails: unable to reach crates.io index in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931c252a4d08329b4b1b060061c300e)